### PR TITLE
Fix JsonParserException when an empty array/object is followed by anything

### DIFF
--- a/src/main/java/com/grack/nanojson/JsonReader.java
+++ b/src/main/java/com/grack/nanojson/JsonReader.java
@@ -249,6 +249,7 @@ public final class JsonReader {
 		if (inObject) {
 			if (token == JsonTokener.TOKEN_OBJECT_END) {
 				inObject = states.get(--stateIndex);
+				first = false;
 				return false;
 			}
 			
@@ -268,6 +269,7 @@ public final class JsonReader {
 		} else {
 			if (token == JsonTokener.TOKEN_ARRAY_END) {
 				inObject = states.get(--stateIndex);
+				first = false;
 				return false;
 			}
 			if (!first) {

--- a/src/test/java/com/grack/nanojson/JsonReaderTest.java
+++ b/src/test/java/com/grack/nanojson/JsonReaderTest.java
@@ -157,7 +157,44 @@ public class JsonReaderTest {
 		assertFalse(reader.next());
 		assertFalse(reader.next());
 	}
-	
+
+	/**
+	 * Test reading an multiple arrays (including an empty one) in a object.
+	 */
+	@Test
+	public void testArraysInObject() throws JsonParserException {
+		String json = createArraysInObject();
+		JsonReader reader = JsonReader.from(json);
+
+		reader.object();
+		while (reader.next()) {
+			reader.key();
+
+			reader.array();
+			while (reader.next())
+				reader.intVal();
+		}
+	}
+
+	private String createArraysInObject() {
+		//@formatter:off
+		String json = JsonWriter.string()
+				.object()
+					.array("a")
+						.value(1)
+						.value(3)
+					.end()
+					.array("b")
+					.end()
+					.array("c")
+						.value(0)
+					.end()
+				.end()
+			.done();
+		//@formatter:on
+		return json;
+	}
+
 	/**
 	 * Test the {@link Users} class from java-json-benchmark.
 	 */


### PR DESCRIPTION
The `JsonReader` throws a `JsonParserException: token mismatch (expected [8], was 1)` when trying to read anything after an empty array/object. This PR add a test to highlight this problem and a fix.

The problem was that when you pass on an empty array (or object) `first` is set to `true` and this value is kept even after ending the array. This causes an error when trying to read the next value because the comma is not expected when it should be.