### PR TITLE
Add getLong variants into JsonArray an JsonObject

### DIFF
--- a/src/main/java/com/grack/nanojson/JsonArray.java
+++ b/src/main/java/com/grack/nanojson/JsonArray.java
@@ -153,6 +153,23 @@ public class JsonArray extends ArrayList<Object> {
 	}
 
 	/**
+	 * Returns the {@link Long} at the given index, or 0 if it does not exist or is the wrong type.
+	 */
+	public long getLong(int key) {
+		return getLong(key, 0);
+	}
+
+	/**
+	 * Returns the {@link Long} at the given index, or the default if it does not exist or is the wrong type.
+	 */
+	public long getLong(int key, long default_) {
+		Object o = get(key);
+		if (o instanceof Number)
+			return ((Number)o).longValue();
+		return default_;
+	}
+
+	/**
 	 * Returns the {@link Number} at the given index, or null if it does not exist or is the wrong type.
 	 */
 	public Number getNumber(int key) {

--- a/src/main/java/com/grack/nanojson/JsonObject.java
+++ b/src/main/java/com/grack/nanojson/JsonObject.java
@@ -144,6 +144,23 @@ public class JsonObject extends HashMap<String, Object> {
 	}
 
 	/**
+	 * Returns the {@link Long} at the given key, or 0 if it does not exist or is the wrong type.
+	 */
+	public long getLong(String key) {
+		return getLong(key, 0);
+	}
+
+	/**
+	 * Returns the {@link Long} at the given key, or the default if it does not exist or is the wrong type.
+	 */
+	public long getLong(String key, long default_) {
+		Object o = get(key);
+		if (o instanceof Number)
+			return ((Number)o).longValue();
+		return default_;
+	}
+
+	/**
 	 * Returns the {@link Number} at the given key, or null if it does not exist or is the wrong type.
 	 */
 	public Number getNumber(String key) {

--- a/src/test/java/com/grack/nanojson/JsonTypesTest.java
+++ b/src/test/java/com/grack/nanojson/JsonTypesTest.java
@@ -20,6 +20,7 @@ public class JsonTypesTest {
 		JsonObject o = new JsonObject();
 		o.put("key", 1);
 		assertEquals(1, o.getInt("key"));
+		assertEquals(1L, o.getLong("key"));
 		assertEquals(1.0, o.getDouble("key"), 0.0001f);
 		assertEquals(1.0f, o.getFloat("key"), 0.0001f);
 		assertEquals(1, o.getNumber("key"));
@@ -35,6 +36,7 @@ public class JsonTypesTest {
 		JsonObject o = new JsonObject();
 		o.put("key", "1");
 		assertEquals(0, o.getInt("key"));
+		assertEquals(0L, o.getLong("key"));
 		assertEquals(0, o.getDouble("key"), 0.0001f);
 		assertEquals(0f, o.getFloat("key"), 0.0001f);
 		assertEquals(null, o.getNumber("key"));
@@ -47,6 +49,7 @@ public class JsonTypesTest {
 		JsonObject o = new JsonObject();
 		o.put("key", null);
 		assertEquals(0, o.getInt("key"));
+		assertEquals(0L, o.getLong("key"));
 		assertEquals(0, o.getDouble("key"), 0.0001f);
 		assertEquals(0f, o.getFloat("key"), 0.0001f);
 		assertEquals(null, o.getNumber("key"));
@@ -60,6 +63,7 @@ public class JsonTypesTest {
 				null));
 		o.set(3, 1);
 		assertEquals(1, o.getInt(3));
+		assertEquals(1L, o.getLong(3));
 		assertEquals(1.0, o.getDouble(3), 0.0001f);
 		assertEquals(1.0f, o.getFloat(3), 0.0001f);
 		assertEquals(1, o.getNumber(3));
@@ -76,6 +80,7 @@ public class JsonTypesTest {
 				null));
 		o.set(3, "1");
 		assertEquals(0, o.getInt(3));
+		assertEquals(0L, o.getLong(3));
 		assertEquals(0, o.getDouble(3), 0.0001f);
 		assertEquals(0, o.getFloat(3), 0.0001f);
 		assertEquals(null, o.getNumber(3));


### PR DESCRIPTION
Just converted a project from vert.x Json to nanojson. We use snowflakes, which are longs, as IDs, so I missed getLong methods.

This PR just adds getLong methods in JsonArray and JsonObject.