### PR TITLE
Automatic module name in manifest

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -31,6 +31,7 @@
 	<!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
 	<module name="NewlineAtEndOfFile">
 		<property name="fileExtensions" value="java"/>
+		<property name="lineSeparator" value="lf" />
 	</module>
 
 	<!-- Checks that property files contain the same keys. -->

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,17 @@
                 <version>3.8.2</version>
                 <configuration>
                 </configuration>
-            </plugin>
+            </plugin>	<plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-jar-plugin</artifactId>
+		<configuration>
+			<archive>
+				<manifestEntries>
+					<Automatic-Module-Name>com.grack.nanojson</Automatic-Module-Name>
+				</manifestEntries>
+			</archive>
+		</configuration>
+	</plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,8 @@
                 <version>3.8.2</version>
                 <configuration>
                 </configuration>
-            </plugin>	<plugin>
+            </plugin>
+	<plugin>
 		<groupId>org.apache.maven.plugins</groupId>
 		<artifactId>maven-jar-plugin</artifactId>
 		<configuration>


### PR DESCRIPTION
Automatic module name in manifest, plus fix to check-styles to specify that *nix style line-endings be used