### PR TITLE
Updated test suite URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ These helper types also provide a builder that can be used in the same way as a 
 
 ## Compliance
 
-  * Passes all of the http://www.json.org/JSON_checker/ tests, minus the test that enforces results not be a string and one that tests nesting depth for arrays
-  * Passes the sample JSON torture test from http://code.google.com/p/json-test-suite/
+  * Passes all of the https://www.json.org/JSON_checker/ tests, minus the test that enforces results not be a string and one that tests nesting depth for arrays
+  * Passes the sample JSON torture test from https://github.com/nst/JSONTestSuite
   * Passes the tests from the YUI browser JSON test suite
 
 ## Release steps


### PR DESCRIPTION
The JSON test suite is no longer available on Google Code. I changed it to the JSON test suite I found on Github. I think they are different projects, but nanojson passes all tests in the latter too.

The JSON checker page is available over HTTPS.