### PR TITLE
Support custom type, such as java.util.Date or beans

### DIFF
--- a/src/main/java/com/grack/nanojson/JsonBuilder.java
+++ b/src/main/java/com/grack/nanojson/JsonBuilder.java
@@ -19,6 +19,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Stack;
 
+import com.grack.nanojson.ext.CustomObjectConverter;
+
 /**
  * Builds a {@link JsonObject} or {@link JsonArray}.
  * 
@@ -207,5 +209,11 @@ public final class JsonBuilder<T> implements JsonSink<JsonBuilder<T>> {
 		} catch (ClassCastException e) {
 			throw new JsonWriterException("Attempted to write a non-keyed value to a JsonObject");
 		}
+	}
+
+	@Override
+	public void setCustomObjectConverter(CustomObjectConverter converter) {
+		throw new UnsupportedOperationException();
+		
 	}
 }

--- a/src/main/java/com/grack/nanojson/JsonSink.java
+++ b/src/main/java/com/grack/nanojson/JsonSink.java
@@ -3,6 +3,8 @@ package com.grack.nanojson;
 import java.util.Collection;
 import java.util.Map;
 
+import com.grack.nanojson.ext.CustomObjectConverter;
+
 /**
  * Common interface for {@link JsonAppendableWriter}, {@link JsonStringWriter} and {@link JsonBuilder}.
  * 
@@ -144,4 +146,11 @@ public interface JsonSink<SELF extends JsonSink<SELF>> {
 	 * Ends the current array or object.
 	 */
 	SELF end();
+	
+	/**
+	 * Set custom object converter.
+	 * @param converter
+	 */
+	void setCustomObjectConverter(CustomObjectConverter converter);
+
 }

--- a/src/main/java/com/grack/nanojson/JsonWriterBase.java
+++ b/src/main/java/com/grack/nanojson/JsonWriterBase.java
@@ -22,6 +22,9 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.Map;
 
+import com.grack.nanojson.ext.CustomObjectConverter;
+import com.grack.nanojson.ext.DefaultCustomObjectConverter;
+
 /**
  * Internal class that handles emitting to an {@link Appendable}. Users only see
  * the public subclasses, {@link JsonStringWriter} and
@@ -60,6 +63,8 @@ class JsonWriterBase<SELF extends JsonWriterBase<SELF>> implements
 	 * Current indent amount.
 	 */
 	private int indent = 0;
+	
+	private CustomObjectConverter customObjectConverter = new DefaultCustomObjectConverter();
 
 	JsonWriterBase(Appendable appendable, String indent) {
 		this.appendable = appendable;
@@ -77,6 +82,11 @@ class JsonWriterBase<SELF extends JsonWriterBase<SELF>> implements
 		utf8 = true;
 		buffer = null;
 		bb = new byte[BUFFER_SIZE];
+	}
+
+	@Override
+	public void setCustomObjectConverter(CustomObjectConverter converter) {
+		this.customObjectConverter = converter;
 	}
 
 	/**
@@ -167,8 +177,7 @@ class JsonWriterBase<SELF extends JsonWriterBase<SELF>> implements
 				value(Array.get(o, i));
 			return end();
 		} else
-			throw new JsonWriterException("Unable to handle type: "
-					+ o.getClass());
+			return value(customObjectConverter.convert(o));
 	}
 
 	@Override
@@ -192,10 +201,9 @@ class JsonWriterBase<SELF extends JsonWriterBase<SELF>> implements
 				value(Array.get(o, i));
 			return end();
 		} else
-			throw new JsonWriterException("Unable to handle type: "
-					+ o.getClass());
+			return value(key, customObjectConverter.convert(o));
 	}
-
+	
 	@Override
 	public SELF value(String s) {
 		if (s == null)

--- a/src/main/java/com/grack/nanojson/JsonWriterException.java
+++ b/src/main/java/com/grack/nanojson/JsonWriterException.java
@@ -21,11 +21,11 @@ package com.grack.nanojson;
 public class JsonWriterException extends RuntimeException {
 	private static final long serialVersionUID = 1L;
 
-	JsonWriterException(String message) {
+	public JsonWriterException(String message) {
 		super(message);
 	}
 
-	JsonWriterException(Throwable t) {
+	public JsonWriterException(Throwable t) {
 		super(t);
 	}
 }

--- a/src/main/java/com/grack/nanojson/ext/CustomObjectConverter.java
+++ b/src/main/java/com/grack/nanojson/ext/CustomObjectConverter.java
@@ -1,0 +1,13 @@
+package com.grack.nanojson.ext;
+
+/**
+ * Custom type to standard type converter
+ */
+public interface CustomObjectConverter {
+	/**
+	 * convert custom object to nanojson known types
+	 * @param object
+	 * @return
+	 */
+	Object convert(Object object);
+}

--- a/src/main/java/com/grack/nanojson/ext/DefaultCustomObjectConverter.java
+++ b/src/main/java/com/grack/nanojson/ext/DefaultCustomObjectConverter.java
@@ -1,0 +1,13 @@
+package com.grack.nanojson.ext;
+
+import com.grack.nanojson.JsonWriterException;
+
+public class DefaultCustomObjectConverter implements CustomObjectConverter {
+
+	@Override
+	public Object convert(Object object) {
+		throw new JsonWriterException("Unable to handle type: "
+				+ object.getClass());
+	}
+
+}

--- a/src/test/java/com/grack/nanojson/JsonWriterTest.java
+++ b/src/test/java/com/grack/nanojson/JsonWriterTest.java
@@ -607,7 +607,7 @@ public class JsonWriterTest {
 
 	@Test
 	public void testCustomObjectAsObject() {
-		// arrange: object (or bean) as json objct
+		// arrange: object (or bean) as json object
 		class CustomClass {
 			public int id = 42;
 		}


### PR DESCRIPTION
User may create a CustomTypeConverter, and set it to JsonWriterBase implementations, then able to serialize arbitary types into json.