### PR TITLE
Make JsonObject extend LinkedHashMap so that keys are ordered.

### DIFF
--- a/src/main/java/com/grack/nanojson/JsonObject.java
+++ b/src/main/java/com/grack/nanojson/JsonObject.java
@@ -15,13 +15,13 @@
  */
 package com.grack.nanojson;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Extends a {@link HashMap} with helper methods to determine the underlying JSON type of the map element.
+ * Extends a {@link LinkedHashMap} with helper methods to determine the underlying JSON type of the map element.
  */
-public class JsonObject extends HashMap<String, Object> {
+public class JsonObject extends LinkedHashMap<String, Object> {
 	private static final long serialVersionUID = 1L;
 
 	/**
@@ -71,7 +71,7 @@ public class JsonObject extends HashMap<String, Object> {
 	public JsonArray getArray(String key, JsonArray default_) {
 		Object o = get(key);
 		if (o instanceof JsonArray)
-			return (JsonArray)get(key);
+			return (JsonArray) o;
 		return default_;
 	}
 
@@ -190,7 +190,7 @@ public class JsonObject extends HashMap<String, Object> {
 	public JsonObject getObject(String key, JsonObject default_) {
 		Object o = get(key);
 		if (o instanceof JsonObject)
-			return (JsonObject)get(key);
+			return (JsonObject) o;
 		return default_;
 	}
 
@@ -207,7 +207,7 @@ public class JsonObject extends HashMap<String, Object> {
 	public String getString(String key, String default_) {
 		Object o = get(key);
 		if (o instanceof String)
-			return (String)get(key);
+			return (String) o;
 		return default_;
 	}
 

--- a/src/test/java/com/grack/nanojson/JsonTypesTest.java
+++ b/src/test/java/com/grack/nanojson/JsonTypesTest.java
@@ -3,6 +3,7 @@ package com.grack.nanojson;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -184,4 +185,23 @@ public class JsonTypesTest {
 		JsonObject.builder().value(1);
 	}
 
+	@Test
+	public void testJsonKeyOrder() {
+		JsonObject a = JsonObject
+			.builder()
+			.value("key01", 1)
+			.value("key02", 2)
+			.value("key03", 3)
+			.value("key04", 4)
+			.done();
+
+		assertArrayEquals(
+			new String [] {
+				"key01",
+				"key02",
+				"key03",
+				"key04"
+			},
+			a.keySet().toArray(new String[0]));
+	}
 }


### PR DESCRIPTION
A small change that makes JsonObject a subclass of LinkedHashmap to preserve key ordering (which is occasionally needed, for example when you wish to read-manipulate-write JSON without shuffling its structure).

Piggybacking a few double calls to get(key) that can be avoided.