### PR TITLE
Removed unreachable state condition from numbers parsing.

### DIFF
--- a/src/main/java/com/grack/nanojson/JsonTokener.java
+++ b/src/main/java/com/grack/nanojson/JsonTokener.java
@@ -213,13 +213,10 @@ final class JsonTokener {
 				sw:
 				switch (state) {
 				case 1: // start leading negative
-					if (nc == '-' && state == 0) {
-						ns = 1; break sw;
-					}
 					if (nc == '0') {
 						ns = 3; break sw;
 					}
-					if (nc >= '0' && nc <= '9') {
+					if (nc > '0' && nc <= '9') {
 						ns = 2; break sw;
 					}
 					break;


### PR DESCRIPTION
IntelliJ highlighted this one - and indeed, seems like a remnant of a previous version of the state parser's code when the initial character wasn't already buffered. 