### PR TITLE
Add a method to JsonSink to allow separate writing of key and value

### DIFF
--- a/src/main/java/com/grack/nanojson/JsonSink.java
+++ b/src/main/java/com/grack/nanojson/JsonSink.java
@@ -159,4 +159,9 @@ public interface JsonSink<SELF extends JsonSink<SELF>> {
 	 * Ends the current array or object.
 	 */
 	SELF end();
+
+	/**
+	 * Writes the key of a key/value pair.
+	 */
+	SELF key(String key);
 }

--- a/src/test/java/com/grack/nanojson/JsonBuilderTest.java
+++ b/src/test/java/com/grack/nanojson/JsonBuilderTest.java
@@ -1,0 +1,26 @@
+package com.grack.nanojson;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JsonBuilderTest {
+	@Test(expected = JsonWriterException.class)
+	public void testFailureKeyInArray() {
+		new JsonBuilder<>(new JsonArray()).key("a");
+	}
+
+	@Test(expected = JsonWriterException.class)
+	public void testFailureKeyWhileKeyPending() {
+		new JsonBuilder<>(new JsonObject()).key("a").key("b");
+	}
+
+	@Test
+	public void testSeparateKeyWriting() {
+		JsonObject actual = new JsonBuilder<>(new JsonObject()).key("a").value(1).key("b").value(2).done();
+		JsonObject expected = new JsonObject();
+		expected.put("a", 1);
+		expected.put("b", 2);
+		assertEquals(expected, actual);
+	}
+}

--- a/src/test/java/com/grack/nanojson/JsonWriterTest.java
+++ b/src/test/java/com/grack/nanojson/JsonWriterTest.java
@@ -132,6 +132,16 @@ public class JsonWriterTest {
 				.end().done());
 	}
 
+	@Test
+	public void testSeparateKeyWriting() {
+		assertEquals("{\"a\":null}",
+				JsonWriter.string().object().key("a").value((Number) null).end()
+						.done());
+		assertEquals("{\"a\":{\"b\":null}}",
+				JsonWriter.string().object().key("a").object().value("b", (Number) null)
+						.end().end().done());
+	}
+
 	/**
 	 * Test escaping of chars < 256.
 	 */
@@ -521,6 +531,16 @@ public class JsonWriterTest {
 		} catch (JsonWriterException e) {
 			// OK
 		}
+	}
+
+	@Test(expected = JsonWriterException.class)
+	public void testFailureRepeatedKey() {
+		JsonWriter.string().object().key("a").value("b", 2).end().done();
+	}
+
+	@Test(expected = JsonWriterException.class)
+	public void testFailureRepeatedKey2() {
+		JsonWriter.string().object().key("a").key("b").end().done();
 	}
 
 	@Test


### PR DESCRIPTION
Solves #89

I added a `key` method to `JsonSink` - instead of just adding it to `JsonWriterBase`. This escalated a tiny bit since I then had to implement the method in `JsonBuilder` as well, which did not yet have its own test - being covered by the `JsonWriterTest`, I presume.

Although `JsonWriterBase` could _immediately_ write the key to the underlying stream, I also implemented the feature in the "pending key" style, since it will then read very similarly in both `JsonWriterBase` and `JsonBuilder`.

It's not quite clear to me what fields in JSON objects are called, but from the tests/error messages in the library, I picked up that you're calling them "key" :)