### PR TITLE
Helper methods

### DIFF
--- a/src/main/java/com/grack/nanojson/JsonArray.java
+++ b/src/main/java/com/grack/nanojson/JsonArray.java
@@ -36,7 +36,9 @@ public class JsonArray extends ArrayList<Object> {
 	}
 
 	/**
-	 * Creates an empty {@link JsonArray} with the default initial capacity.
+	 * Creates an empty {@link JsonArray} with the specified initial capacity.
+	 *
+	 * @param initialCapacity the initial capacity of the array
 	 */
 	public JsonArray(int initialCapacity) {
 		super(initialCapacity);
@@ -258,48 +260,112 @@ public class JsonArray extends ArrayList<Object> {
 		return get(key) instanceof String;
 	}
 
+	/**
+	 * Performs the given action for each element of the Array that represents a JsonObject
+	 * until all elements have been processed
+	 * or the action throws an exception. Actions are performed in the order of iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachObject(Consumer<JsonObject> consumer) {
 		forEach(o -> {
 			if (o instanceof JsonObject) consumer.accept((JsonObject) o);
 		});
 	}
 
+	/**
+	 * Performs the given action for each element of the Array that represents a JsonArray
+	 * until all elements have been processed
+	 * or the action throws an exception. Actions are performed in the order of iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachArray(Consumer<JsonArray> consumer) {
 		forEach(o -> {
 			if (o instanceof JsonArray) consumer.accept((JsonArray) o);
 		});
 	}
 
+	/**
+	 * Performs the given action for each element of the Array that represents a Number
+	 * until all elements have been processed
+	 * or the action throws an exception. Actions are performed in the order of iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachNumber(Consumer<Number> consumer) {
 		forEach(o -> {
 			if (o instanceof Number) consumer.accept((Number) o);
 		});
 	}
 
+	/**
+	 * Performs the given action for each element of the Array that represents a Boolean
+	 * until all elements have been processed
+	 * or the action throws an exception. Actions are performed in the order of iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachBoolean(Consumer<Boolean> consumer) {
 		forEach(o -> {
 			if (o instanceof Boolean) consumer.accept((Boolean) o);
 		});
 	}
 
+	/**
+	 * Performs the given action for each element of the Array that represents a Float
+	 * until all elements have been processed
+	 * or the action throws an exception. Actions are performed in the order of iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachFloat(Consumer<Float> consumer) {
 		forEach(o -> {
 			if (o instanceof Number) consumer.accept(((Number) o).floatValue());
 		});
 	}
 
+	/**
+	 * Performs the given action for each element of the Array that represents a Double
+	 * until all elements have been processed
+	 * or the action throws an exception. Actions are performed in the order of iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachDouble(DoubleConsumer consumer) {
 		forEach(o -> {
 			if (o instanceof Number) consumer.accept(((Number) o).doubleValue());
 		});
 	}
 
+	/**
+	 * Performs the given action for each element of the Array that represents an Int
+	 * until all elements have been processed
+	 * or the action throws an exception. Actions are performed in the order of iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachInt(IntConsumer consumer) {
 		forEach(o -> {
 			if (o instanceof Number) consumer.accept(((Number) o).intValue());
 		});
 	}
 
+	/**
+	 * Performs the given action for each element of the Array that represents a Long
+	 * until all elements have been processed
+	 * or the action throws an exception. Actions are performed in the order of iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachLong(LongConsumer consumer) {
 		forEach(o -> {
 			if (o instanceof Number) consumer.accept(((Number) o).longValue());

--- a/src/main/java/com/grack/nanojson/JsonArray.java
+++ b/src/main/java/com/grack/nanojson/JsonArray.java
@@ -18,6 +18,10 @@ package com.grack.nanojson;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.DoubleConsumer;
+import java.util.function.IntConsumer;
+import java.util.function.LongConsumer;
 
 /**
  * Extends an {@link ArrayList} with helper methods to determine the underlying JSON type of the list element.
@@ -252,5 +256,53 @@ public class JsonArray extends ArrayList<Object> {
 	 */
 	public boolean isString(int key) {
 		return get(key) instanceof String;
+	}
+
+	public void forEachObject(Consumer<JsonObject> consumer) {
+		forEach(o -> {
+			if (o instanceof JsonObject) consumer.accept((JsonObject) o);
+		});
+	}
+
+	public void forEachArray(Consumer<JsonArray> consumer) {
+		forEach(o -> {
+			if (o instanceof JsonArray) consumer.accept((JsonArray) o);
+		});
+	}
+
+	public void forEachNumber(Consumer<Number> consumer) {
+		forEach(o -> {
+			if (o instanceof Number) consumer.accept((Number) o);
+		});
+	}
+
+	public void forEachBoolean(Consumer<Boolean> consumer) {
+		forEach(o -> {
+			if (o instanceof Boolean) consumer.accept((Boolean) o);
+		});
+	}
+
+	public void forEachFloat(Consumer<Float> consumer) {
+		forEach(o -> {
+			if (o instanceof Number) consumer.accept(((Number) o).floatValue());
+		});
+	}
+
+	public void forEachDouble(DoubleConsumer consumer) {
+		forEach(o -> {
+			if (o instanceof Number) consumer.accept(((Number) o).doubleValue());
+		});
+	}
+
+	public void forEachInt(IntConsumer consumer) {
+		forEach(o -> {
+			if (o instanceof Number) consumer.accept(((Number) o).intValue());
+		});
+	}
+
+	public void forEachLong(LongConsumer consumer) {
+		forEach(o -> {
+			if (o instanceof Number) consumer.accept(((Number) o).longValue());
+		});
 	}
 }

--- a/src/main/java/com/grack/nanojson/JsonObject.java
+++ b/src/main/java/com/grack/nanojson/JsonObject.java
@@ -247,48 +247,112 @@ public class JsonObject extends LinkedHashMap<String, Object> {
 		return get(key) instanceof String;
 	}
 
+	/**
+	 * Performs the given action for each entry in this map where the value represents a JsonObject
+	 * until all entries have been processed or the action throws an exception.
+	 * Actions are performed in the order of entry set iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachObject(BiConsumer<String, JsonObject> consumer) {
 		forEach((key, value) -> {
 			if (value instanceof JsonObject) consumer.accept(key, (JsonObject) value);
 		});
 	}
 
+	/**
+	 * Performs the given action for each entry in this map where the value represents a JsonArray
+	 * until all entries have been processed or the action throws an exception.
+	 * Actions are performed in the order of entry set iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachArray(BiConsumer<String, JsonArray> consumer) {
 		forEach((key, value) -> {
 			if (value instanceof JsonArray) consumer.accept(key, (JsonArray) value);
 		});
 	}
 
+	/**
+	 * Performs the given action for each entry in this map where the value represents a Boolean
+	 * until all entries have been processed or the action throws an exception.
+	 * Actions are performed in the order of entry set iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachBoolean(BiConsumer<String, Boolean> consumer) {
 		forEach((key, value) -> {
 			if (value instanceof Boolean) consumer.accept(key, (Boolean) value);
 		});
 	}
 
+	/**
+	 * Performs the given action for each entry in this map where the value represents a Number
+	 * until all entries have been processed or the action throws an exception.
+	 * Actions are performed in the order of entry set iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachNumber(BiConsumer<String, Number> consumer) {
 		forEach((key, value) -> {
 			if (value instanceof Number) consumer.accept(key, (Number) value);
 		});
 	}
 
+	/**
+	 * Performs the given action for each entry in this map where the value represents an Int
+	 * until all entries have been processed or the action throws an exception.
+	 * Actions are performed in the order of entry set iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachInt(BiConsumer<String, Integer> consumer) {
 		forEach((key, value) -> {
 			if (value instanceof Number) consumer.accept(key, ((Number) value).intValue());
 		});
 	}
 
+	/**
+	 * Performs the given action for each entry in this map where the value represents a Long
+	 * until all entries have been processed or the action throws an exception.
+	 * Actions are performed in the order of entry set iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachLong(BiConsumer<String, Long> consumer) {
 		forEach((key, value) -> {
 			if (value instanceof Number) consumer.accept(key, ((Number) value).longValue());
 		});
 	}
 
+	/**
+	 * Performs the given action for each entry in this map where the value represents a Float
+	 * until all entries have been processed or the action throws an exception.
+	 * Actions are performed in the order of entry set iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachFloat(BiConsumer<String, Float> consumer) {
 		forEach((key, value) -> {
 			if (value instanceof Number) consumer.accept(key, ((Number) value).floatValue());
 		});
 	}
 
+	/**
+	 * Performs the given action for each entry in this map where the value represents a Double
+	 * until all entries have been processed or the action throws an exception.
+	 * Actions are performed in the order of entry set iteration.
+	 * Exceptions thrown by the action are relayed to the caller.
+	 *
+	 * @param consumer the action to perform
+	 */
 	public void forEachDouble(BiConsumer<String, Double> consumer) {
 		forEach((key, value) -> {
 			if (value instanceof Number) consumer.accept(key, ((Number) value).doubleValue());

--- a/src/main/java/com/grack/nanojson/JsonObject.java
+++ b/src/main/java/com/grack/nanojson/JsonObject.java
@@ -17,6 +17,7 @@ package com.grack.nanojson;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 /**
  * Extends a {@link LinkedHashMap} with helper methods to determine the underlying JSON type of the map element.
@@ -244,5 +245,53 @@ public class JsonObject extends LinkedHashMap<String, Object> {
 	 */
 	public boolean isString(String key) {
 		return get(key) instanceof String;
+	}
+
+	public void forEachObject(BiConsumer<String, JsonObject> consumer) {
+		forEach((key, value) -> {
+			if (value instanceof JsonObject) consumer.accept(key, (JsonObject) value);
+		});
+	}
+
+	public void forEachArray(BiConsumer<String, JsonArray> consumer) {
+		forEach((key, value) -> {
+			if (value instanceof JsonArray) consumer.accept(key, (JsonArray) value);
+		});
+	}
+
+	public void forEachBoolean(BiConsumer<String, Boolean> consumer) {
+		forEach((key, value) -> {
+			if (value instanceof Boolean) consumer.accept(key, (Boolean) value);
+		});
+	}
+
+	public void forEachNumber(BiConsumer<String, Number> consumer) {
+		forEach((key, value) -> {
+			if (value instanceof Number) consumer.accept(key, (Number) value);
+		});
+	}
+
+	public void forEachInt(BiConsumer<String, Integer> consumer) {
+		forEach((key, value) -> {
+			if (value instanceof Number) consumer.accept(key, ((Number) value).intValue());
+		});
+	}
+
+	public void forEachLong(BiConsumer<String, Long> consumer) {
+		forEach((key, value) -> {
+			if (value instanceof Number) consumer.accept(key, ((Number) value).longValue());
+		});
+	}
+
+	public void forEachFloat(BiConsumer<String, Float> consumer) {
+		forEach((key, value) -> {
+			if (value instanceof Number) consumer.accept(key, ((Number) value).floatValue());
+		});
+	}
+
+	public void forEachDouble(BiConsumer<String, Double> consumer) {
+		forEach((key, value) -> {
+			if (value instanceof Number) consumer.accept(key, ((Number) value).doubleValue());
+		});
 	}
 }


### PR DESCRIPTION
#Issue to be solved
In many instances, JsonObjects and arrays are structured in a uniform way, so that we know that a JsonArray contains only JsonObjects, for example.

This however poses a challenge when iterating: The type bound for `JsonObject` and `JsonArray` is `Object`, so every Object has to be iterated and then cast manually, leading to much clutter in client code.

#The Solution
Add Helper methods to `JsonArray` and `JsonObject` that resembe the `forEach()` method, but accepting a (Bi-)Consumer of the desired type. Only elements whose type matches the wanted type are handed on to the Consumers in order to prevent `ClassCastException`s.

#Alternatives
The alternative I Use uses unchecked casting and then iteration, something akin to
```java
    JsonObject lib; // = ...
    @SuppressWarnings({"unchecked", "rawtypes"})
    List<JsonObject> rules = (List)lib.getArray("rules");
    for(JsonObject rule : rules) doSomething(rule);
```
but this also erases type safety, potentially leading to unexpected `ClassCastException`s, furthermore we loose all array specific methods if we don't sacrifice an extra line of code for an intermediate variable.

#Risks and Assumptions
The main risk lies in the user maybe not expecting not to consume all elements in the case of incompatible objects found. These users, however, can always fall back to the standard List/Map `forEach()` methods.