### PR TITLE
Fixes #98 by following modern Javascript's behaviour regarding NaN/Infinities.

### DIFF
--- a/src/main/java/com/grack/nanojson/JsonWriterBase.java
+++ b/src/main/java/com/grack/nanojson/JsonWriterBase.java
@@ -248,7 +248,7 @@ class JsonWriterBase<SELF extends JsonWriterBase<SELF>> implements
 	@Override
 	public SELF value(Number n) {
 		preValue();
-		if (n == null)
+		if (n == null || nullish(n))
 			raw(NULL);
 		else
 			raw(n.toString());
@@ -618,5 +618,23 @@ class JsonWriterBase<SELF extends JsonWriterBase<SELF>> implements
 	private boolean shouldBeEscaped(char c) {
 		return c < ' ' || (c >= '\u0080' && c < '\u00a0')
 				|| (c >= '\u2000' && c < '\u2100');
+	}
+
+	/**
+	 * Returns true if the number becomes null when converted to JSON. json.org spec does not specify
+	 * NaN or Infinity as numbers, and modern JavaScript engines convert them to null.
+	 * @param n a number
+	 * @return true if the number is nullish.
+	 */
+	private boolean nullish(Number n) {
+		if (n instanceof Double) {
+			Double d = (Double) n;
+			return d.isNaN() || d.isInfinite();
+		}
+        if (n instanceof Float) {
+			Float f = (Float) n;
+			return f.isNaN() || f.isInfinite();
+        }
+        return false;
 	}
 }


### PR DESCRIPTION
![Image](https://github.com/user-attachments/assets/f405357e-5668-42b6-8093-287a9366a2dd)

Going by `JSON.stringify`'s implementation on Node, Chrome and Firefox, NaN should become null.

![Image](https://github.com/user-attachments/assets/557be4e3-e2b4-4305-a835-cc6437b9331d)

Same thing for positive/negative infinity. Fixes #98.