### PR TITLE
OSGi Support

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -170,9 +170,6 @@
                     <debug>true</debug>
                     <debuglevel>none</debuglevel>
                     <release>8</release>
-                    <archive>
-                        <manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
-                    </archive>
                     <compilerArgument>-Xlint:all</compilerArgument>
                     <compilerArguments>
                         <Werror />
@@ -186,17 +183,40 @@
                 <configuration>
                 </configuration>
             </plugin>
-	<plugin>
-		<groupId>org.apache.maven.plugins</groupId>
-		<artifactId>maven-jar-plugin</artifactId>
-		<configuration>
-			<archive>
-				<manifestEntries>
-					<Automatic-Module-Name>com.grack.nanojson</Automatic-Module-Name>
-				</manifestEntries>
-			</archive>
-		</configuration>
-	</plugin>
+          <plugin>
+              <groupId>biz.aQute.bnd</groupId>
+              <artifactId>bnd-maven-plugin</artifactId>
+              <extensions>true</extensions>
+              <executions>
+                  <execution>
+                      <id>jar</id>
+                      <goals>
+                          <goal>jar</goal>
+                      </goals>
+                          <configuration>
+                              <bnd><![CDATA[
+                                  Bundle-SymbolicName: ${groupId}.${artifactId}
+                                  Export-Package: com.grack.nanojson
+                                  -jpms-module-info: com.grack.nanojson
+                                  -noextraheaders: 
+                                  -removeheaders: \
+                                    Tool, \
+                                    Bnd-LastModified, \
+                                    Bnd-ManifestVersion, \
+                                    Build-Jdk, \
+                                    Built-By, \
+                                    Created-By, \
+                                    Private-Package, \
+                                    Bundle-DocURL, \
+                                    Bundle-Name, \
+                                    Bundle-Vendor,\
+                                    Bundle-Description,\
+                                    Bundle-SCM
+                              ]]></bnd>
+                          </configuration>
+                  </execution>
+              </executions>
+          </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Hi!

I'd like to use `nanojson` within an OSGi framework. To make this possible, the JAR manifest needs a few minimal metadata entries – namely:

* `Export-Package` (to make the main package available)
* `Import-Package` (for resolving dependencies)
* `Bundle-SymbolicName` (to identify the bundle)
* and optionally a minimal runtime requirement (e.g., `Bundle-RequiredExecutionEnvironment` or Java version)

To keep the library as lightweight as possible, I’ve added only what’s absolutely necessary. Specifically, the package `com.grack.nanojson` is marked for export so it can be used by other bundles.

As an added benefit, this also allows for easy generation of a `module-info.class` for JPMS:

```java
open module com.grack.nanojson {
  requires java.base;
  exports com.grack.nanojson;
}
```

To support this, I replaced the `maven-jar-plugin` with the `bnd-maven-plugin`, which automatically generates the correct OSGi manifest and optional module-info.

Let me know if you have any questions – happy to help!

Best regards,
Stefan